### PR TITLE
Better windows support + s3:// asset URL support

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ Condensation.prototype.condense = function() {
 
     templateData.s3 = s3opts.aws;
     templateData.s3.awsPath = s3.endpoint.href+url.resolve(s3opts.aws.bucket,s3opts.prefix);
+    templateData.s3.awsPathInS3Format = "s3://" + s3opts.aws.bucket + "/" + s3opts.prefix;
 
     gulp.task(self.genTaskName('build',i),[self.genTaskName('clean:errors')],function() {
 

--- a/index.js
+++ b/index.js
@@ -83,8 +83,8 @@ Condensation.prototype.condense = function() {
     });
 
     templateData.s3 = s3opts.aws;
-    templateData.s3.awsPath = s3.endpoint.href+url.resolve(s3opts.aws.bucket,s3opts.prefix);
-    templateData.s3.awsPathInS3Format = "s3://" + s3opts.aws.bucket + "/" + s3opts.prefix;
+    templateData.s3.awsPath = url.resolve(s3.endpoint.href + s3opts.aws.bucket + "/", s3opts.prefix) + "/";
+    templateData.s3.awsPathInS3Format = "s3://" + s3opts.aws.bucket + "/" + s3opts.prefix + "/";
 
     gulp.task(self.genTaskName('build',i),[self.genTaskName('clean:errors')],function() {
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ path = require('path'),
 rename = require('gulp-rename'),
 
 through = require('through2');
+url = require('url');
 
 var DEFAULT_S3_PREFIX = exports.DEFAULT_S3_PREFIX = '';
 var DEFAULT_TASK_PREFIX = exports.DEFAULT_TASK_PREFIX = 'condensation';
@@ -82,7 +83,7 @@ Condensation.prototype.condense = function() {
     });
 
     templateData.s3 = s3opts.aws;
-    templateData.s3.awsPath = s3.endpoint.href+path.join(s3opts.aws.bucket,s3opts.prefix);
+    templateData.s3.awsPath = s3.endpoint.href+url.resolve(s3opts.aws.bucket,s3opts.prefix);
 
     gulp.task(self.genTaskName('build',i),[self.genTaskName('clean:errors')],function() {
 

--- a/lib/template-helpers/assetS3Url.js
+++ b/lib/template-helpers/assetS3Url.js
@@ -4,7 +4,14 @@ var url = require('url');
 var helper = function (cModule,pPath,hArgs,hOpts,cOpts) {
   var particle = cOpts.particleLoader.loadParticle('asset',cModule,pPath,{parentFile: hOpts.data._file});
 
-  return url.resolve(this.s3.awsPath,particle.relative);
+  var protocol = hOpts.hash.protocol;
+  switch(protocol){
+      case 's3':
+          return url.resolve(this.s3.awsPathInS3Format, particle.relative);
+
+      default:
+          return url.resolve(this.s3.awsPath,particle.relative);
+  }
 };
 
 module.exports.NAME = 'assetS3Url';

--- a/lib/template-helpers/assetS3Url.js
+++ b/lib/template-helpers/assetS3Url.js
@@ -1,7 +1,7 @@
 var url = require('url');
 
-
 var helper = function (cModule,pPath,hArgs,hOpts,cOpts) {
+  //Assumption: The relative path returned never starts with a leading slash. This appears to be the behavior
   var particle = cOpts.particleLoader.loadParticle('asset',cModule,pPath,{parentFile: hOpts.data._file});
 
   var protocol = hOpts.hash.protocol;

--- a/lib/template-helpers/assetS3Url.js
+++ b/lib/template-helpers/assetS3Url.js
@@ -1,11 +1,10 @@
-var path = require('path');
+var url = require('url');
+
 
 var helper = function (cModule,pPath,hArgs,hOpts,cOpts) {
-
   var particle = cOpts.particleLoader.loadParticle('asset',cModule,pPath,{parentFile: hOpts.data._file});
 
-  return path.join(this.s3.awsPath,particle.relative);
-
+  return url.resolve(this.s3.awsPath,particle.relative);
 };
 
 module.exports.NAME = 'assetS3Url';

--- a/lib/template-helpers/templateS3Url.js
+++ b/lib/template-helpers/templateS3Url.js
@@ -1,8 +1,10 @@
+var url = require('url');
+
 var helper = function (cModule,pPath,hArgs,hOpts,cOpts) {
 
     var particle = cOpts.particleLoader.loadParticle('template',cModule,pPath,{parentFile: hOpts.data._file});
 
-    return [hOpts.data.root.s3.awsPath,particle.relative].join('/');
+    return url.resolve(hOpts.data.root.s3.awsPath,particle.relative);
 };
 
 module.exports.NAME = 'templateS3Url';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condensation",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/test/template-helpers/assetS3Url.js
+++ b/test/template-helpers/assetS3Url.js
@@ -1,0 +1,71 @@
+var assert = require("assert");
+var helper = require('../../lib/template-helpers/assetS3Url');
+var async = require('async');
+
+
+
+
+describe('assetS3Url', function(){
+
+    async.each([
+        {
+            description: 'should resolve http path on windows',
+            particlePath: 'particles\\assets\\example.rb',
+            protocol: 'http',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/assets/example.rb'
+        },
+        {
+            description: 'should resolve http path on linux',
+            particlePath: 'particles/assets/example.rb',
+            protocol: 'http',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/assets/example.rb'
+        },
+        {
+            description: 'should resolve s3 path on windows',
+            particlePath: 'particles\\assets\\example.rb',
+            protocol: 's3',
+            expected:  's3://bucket/particles/assets/example.rb'
+        },
+        {
+            description: 'should resolve s3 path on linux',
+            particlePath: 'particles/assets/example.rb',
+            protocol: 's3',
+            expected:  's3://bucket/particles/assets/example.rb'
+        },
+        {
+            description: 'should default to http if no protocol specified',
+            particlePath: 'particles\\assets\\example.rb',
+            protocol: null,
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/assets/example.rb'
+        }
+    ], function(config){
+
+        it(config.description, function(done){
+            //Arrange
+            var hOpts = {
+                data: {_file: null},
+                hash: {protocol: config.protocol}
+            };
+            var cOpts = {
+                particleLoader: {
+                    loadParticle: function(){
+                        return {relative: config.particlePath};
+                    }
+                }
+            };
+            var root = {s3: {awsPath: 'https://s3-eu-west-1.amazonaws.com/bucket/', awsPathInS3Format: 's3://bucket/'}};
+
+            //Act
+            var result = helper.helper.apply(root, [null, null, null, hOpts, cOpts]);
+
+            //Assert
+            assert.equal(result, config.expected);
+            done();
+        });
+
+    });
+
+
+
+
+});

--- a/test/template-helpers/templateS3Url.js
+++ b/test/template-helpers/templateS3Url.js
@@ -1,0 +1,52 @@
+var assert = require("assert");
+var helper = require('../../lib/template-helpers/templateS3Url');
+var async = require('async');
+
+
+
+
+describe('templateS3Url', function(){
+
+    async.each([
+        {
+            description: 'should resolve http path on windows',
+            particlePath: 'particles\\cftemplates\\example.template',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/cftemplates/example.template'
+        },
+        {
+            description: 'should resolve http path on linux',
+            particlePath: 'particles/cftemplates/example.template',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/cftemplates/example.template'
+        }
+    ], function(config){
+
+        it(config.description, function(done){
+            var root = {s3: {awsPath: 'https://s3-eu-west-1.amazonaws.com/bucket/', awsPathInS3Format: 's3://bucket/'}};
+
+            //Arrange
+            var hOpts = {
+                data: {_file: null, root: root},
+                hash: {}
+            };
+            var cOpts = {
+                particleLoader: {
+                    loadParticle: function(){
+                        return {relative: config.particlePath};
+                    }
+                }
+            };
+
+            //Act
+            var result = helper.helper.apply(root, [null, null, null, hOpts, cOpts]);
+
+            //Assert
+            assert.equal(result, config.expected);
+            done();
+        });
+
+    });
+
+
+
+
+});

--- a/test/unitTests.js
+++ b/test/unitTests.js
@@ -1,0 +1,7 @@
+/**
+ * This is a temp solution. The project is not setup to look for tests recursively. If it did, it would also
+ * include the fixtures (projectA/*.js) which are not valid test files. The correct solution is probably to move the
+ * fixtures.
+ */
+require('./template-helpers/assetS3Url');
+require('./template-helpers/templateS3Url');


### PR DESCRIPTION
This pull request fixes a bug for windows users and adds a feature in a related area. I can split this down into multiple pull requests if you just want the bug fix.

On windows, assetS3Url and templateS3Url output with backslashes for the S3 URLs because the code was using path.join which is OS specific. This has been changed to use url.resolve as the output for these helpers is always a URL and should always be a forward slash.

The related feature is also a change to assetS3Url. We are using condensation to template some shell scripts for EMR bootstrapping. In one of those steps we need to reference other assets but using an s3 url rather than http. s3://bucketname/path. To support this we have added an option to assetS3Url: {{{assetS3Url 'setup_drill.rb' protocol="s3"}}}. If protocol==s3 it returns an s3:// url, otherwise the existing behavior is used.
