### PR TITLE
Improved robustness of changed url resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,12 @@ Condensation.prototype.condense = function() {
     });
 
     templateData.s3 = s3opts.aws;
-    templateData.s3.awsPath = url.resolve(s3.endpoint.href + s3opts.aws.bucket + "/", s3opts.prefix) + "/";
+
+    var awsPath = s3.endpoint.href + s3opts.aws.bucket + "/" + s3opts.prefix;
+    if(awsPath.indexOf('/', awsPath.length-1) == -1){
+        awsPath += '/';
+    }
+    templateData.s3.awsPath = awsPath;
     templateData.s3.awsPathInS3Format = "s3://" + s3opts.aws.bucket + "/" + s3opts.prefix + "/";
 
     gulp.task(self.genTaskName('build',i),[self.genTaskName('clean:errors')],function() {

--- a/lib/template-helpers/assetS3Url.js
+++ b/lib/template-helpers/assetS3Url.js
@@ -4,13 +4,18 @@ var helper = function (cModule,pPath,hArgs,hOpts,cOpts) {
   //Assumption: The relative path returned never starts with a leading slash. This appears to be the behavior
   var particle = cOpts.particleLoader.loadParticle('asset',cModule,pPath,{parentFile: hOpts.data._file});
 
+  var relative = particle.relative;
+  if(relative.indexOf('/') == 0 || relative.indexOf('\\') == 0){
+      relative = relative.substr(1);
+  }
+
   var protocol = hOpts.hash.protocol;
   switch(protocol){
       case 's3':
-          return url.resolve(this.s3.awsPathInS3Format, particle.relative);
+          return url.resolve(this.s3.awsPathInS3Format, relative);
 
       default:
-          return url.resolve(this.s3.awsPath,particle.relative);
+          return url.resolve(this.s3.awsPath, relative);
   }
 };
 

--- a/lib/template-helpers/templateS3Url.js
+++ b/lib/template-helpers/templateS3Url.js
@@ -3,8 +3,12 @@ var url = require('url');
 var helper = function (cModule,pPath,hArgs,hOpts,cOpts) {
 
     var particle = cOpts.particleLoader.loadParticle('template',cModule,pPath,{parentFile: hOpts.data._file});
+    var relative = particle.relative;
+    if(relative.indexOf('/') == 0 || relative.indexOf('\\') == 0){
+        relative = relative.substr(1);
+    }
 
-    return url.resolve(hOpts.data.root.s3.awsPath,particle.relative);
+    return url.resolve(hOpts.data.root.s3.awsPath,relative);
 };
 
 module.exports.NAME = 'templateS3Url';

--- a/test/template-helpers/assetS3Url.js
+++ b/test/template-helpers/assetS3Url.js
@@ -21,6 +21,18 @@ describe('assetS3Url', function(){
             expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/assets/example.rb'
         },
         {
+            description: 'should resolve http path on windows with leading slash',
+            particlePath: '\\particles\\assets\\example.rb',
+            protocol: 'http',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/assets/example.rb'
+        },
+        {
+            description: 'should resolve http path on linux with leading slash',
+            particlePath: '/particles/assets/example.rb',
+            protocol: 'http',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/assets/example.rb'
+        },
+        {
             description: 'should resolve s3 path on windows',
             particlePath: 'particles\\assets\\example.rb',
             protocol: 's3',

--- a/test/template-helpers/templateS3Url.js
+++ b/test/template-helpers/templateS3Url.js
@@ -5,7 +5,7 @@ var async = require('async');
 
 
 
-describe.only('templateS3Url', function(){
+describe('templateS3Url', function(){
 
     async.each([
         {

--- a/test/template-helpers/templateS3Url.js
+++ b/test/template-helpers/templateS3Url.js
@@ -5,7 +5,7 @@ var async = require('async');
 
 
 
-describe('templateS3Url', function(){
+describe.only('templateS3Url', function(){
 
     async.each([
         {
@@ -16,6 +16,16 @@ describe('templateS3Url', function(){
         {
             description: 'should resolve http path on linux',
             particlePath: 'particles/cftemplates/example.template',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/cftemplates/example.template'
+        },
+        {
+            description: 'should resolve http path on windows with a leading slash',
+            particlePath: '\\particles\\cftemplates\\example.template',
+            expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/cftemplates/example.template'
+        },
+        {
+            description: 'should resolve http path on linux with a leading slash',
+            particlePath: '/particles/cftemplates/example.template',
             expected:  'https://s3-eu-west-1.amazonaws.com/bucket/particles/cftemplates/example.template'
         }
     ], function(config){


### PR DESCRIPTION
I gave this some additional QA time and found that it was not quite robust enough. Depending on if the user provided a trailing slash on path in their gulp config the URLs would sometimes resolve incorrectly. The code now accounts for a trailing slash, no trailing slash and no path at all.
